### PR TITLE
Made changes in path and in Dockerfile watch.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,12 @@ RUN pip install fastai
 # Install starlette and uvicorn
 RUN pip install starlette uvicorn python-multipart aiohttp
 
+COPY data/ data/
 ADD watch.py watch.py
 
 
 # Run it once to trigger resnet download
-RUN python watch.py
+# RUN python watch.py   # You don't need to do this!
 
 EXPOSE 8008
 

--- a/watch.py
+++ b/watch.py
@@ -94,4 +94,5 @@ if __name__ == "__main__":
     ex: python watch.py serve
     """
     if "serve" in sys.argv:
-        uvicorn.run(app, host="0.0.0.0", port=8081)
+        port = int(os.environ.get("PORT", 8008)) 
+        uvicorn.run(app, host="0.0.0.0",  port=port)


### PR DESCRIPTION
- Re-arranged Model weights path
- Fetching port from OS environment in watch.py. "PORT" property is set by Heroku, so we need to use that PORT
- Added copy command to copy weights in Dockerfile

Signed-off-by: Deepanshu <deepanshu2017@gmail.com>